### PR TITLE
Add named export for Feed

### DIFF
--- a/packages/1_1/index.d.ts
+++ b/packages/1_1/index.d.ts
@@ -1,4 +1,5 @@
 export { default } from './types/feed'
+export { default as Feed } from './types/feed'
 export { default as Attachment } from './types/attachment'
 export { default as Author } from './types/author'
 export { default as Hub } from './types/hub'


### PR DESCRIPTION
So I can do this
```ts
import type { Feed, Item } from "@json-feed-types/1_1";
```

instead of this
```ts
import type { default as Feed, Item } from "@json-feed-types/1_1";
```